### PR TITLE
Fix shadow drawing errors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5323,6 +5323,18 @@ static int update_shadow(frame_settings * fs)
 
     dst = XRenderCreatePicture(xdisplay, cairo_xlib_surface_get_drawable(d.surface),
 			       format, 0, NULL);
+
+    /* draw rectangle */
+    XRenderFillRectangle(xdisplay, PictOpSrc, dst, &clear,
+			 0, 0, d.width, d.height);
+    XRenderFillRectangle(xdisplay, PictOpSrc, dst, &white,
+			 ws->shadow_left_space,
+			 ws->shadow_top_space,
+			 d.width - ws->shadow_left_space -
+			 ws->shadow_right_space,
+			 d.height - ws->shadow_top_space -
+			 ws->shadow_bottom_space);
+
     tmp = XRenderCreatePicture(xdisplay, cairo_xlib_surface_get_drawable(surface),
 			       format, 0, NULL);
 


### PR DESCRIPTION
This PR allows to use shadows with any supported size without visual artifacts.
It fixes #12
![Wrong shadow now fixed](https://user-images.githubusercontent.com/1945127/28638157-ac34ad56-724c-11e7-9fe8-33d69399b06e.png)